### PR TITLE
Fix the compatibility for Firefox 36

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const { EventTarget } = require("sdk/event/target");
-const { emit } = require('sdk/event/core');
-const { Class } = require('sdk/core/heritage');
+var { EventTarget } = require("sdk/event/target");
+var { emit } = require('sdk/event/core');
+var { Class } = require('sdk/core/heritage');
 
-const { get, set } = require('pathfinder/storage');
+var { get, set } = require('pathfinder/storage');
 let json = {};
 
 let getP = get();

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,36 +3,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const tabs = require('sdk/tabs');
-const windows = require('sdk/windows').browserWindows;
-const { data } = require('sdk/self');
-const { on } = require('sdk/event/core');
-const { URL } = require('sdk/url');
-const { isPrivate } = require('sdk/private-browsing');
-const { defer } = require('sdk/core/promise');
-const { when: unload } = require('sdk/system/unload');
+var tabs = require('sdk/tabs');
+var windows = require('sdk/windows').browserWindows;
+var { data } = require('sdk/self');
+var { on } = require('sdk/event/core');
+var { URL } = require('sdk/url');
+var { isPrivate } = require('sdk/private-browsing');
+var { defer } = require('sdk/core/promise');
+var { when: unload } = require('sdk/system/unload');
 let isAustralis = false;
 let toggleBtnPath = "sdk/ui/button/toggle";
 try {
-  const { ToggleButton } = require(toggleBtnPath);
+  var { ToggleButton } = require(toggleBtnPath);
   isAustralis = true;
 }
 catch(e) {
-  const { Widget } = require("sdk/widget");
+  var { Widget } = require("sdk/widget");
 }
 
-const { Redirect } = require('pathfinder/redirect');
+var { Redirect } = require('pathfinder/redirect');
 let redirects = {};
 unload(_ => {
   Array.slice(redirects).forEach(r => r.dispose());
   redirects = {};
 });
 
-const { Database } = require('./database');
+var { Database } = require('./database');
 
-const BUTTON_ID = 'secure-it-jetpack-button';
-const ICON_ON = { 16: './on.gif' };
-const ICON_OFF = { 16: './off.gif' };
+var BUTTON_ID = 'secure-it-jetpack-button';
+var ICON_ON = { 16: './on.gif' };
+var ICON_OFF = { 16: './off.gif' };
 
 function onClick() {
   let tab = tabs.activeTab;


### PR DESCRIPTION
Replace `const` of all to `var`.

https://www.mozilla.org/en-US/firefox/36.0/releasenotes/
The const declaration is now block-scoped and requires an initializer. It also can not be redeclared anymore.